### PR TITLE
Add dependent destroy

### DIFF
--- a/app/models/console.rb
+++ b/app/models/console.rb
@@ -1,5 +1,5 @@
 class Console < ApplicationRecord
-  has_many :reservations
+  has_many :reservations, dependent: :destroy
 
   validates :name, :purchase_price, :rental_price, :description, :photo, presence: true
   validates :purchase_price, :rental_price, numericality: { greater_than: 0, integer_only: true }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,6 @@ class User < ApplicationRecord
   include DeviseTokenAuth::Concerns::User
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  has_many :reservations
+  has_many :reservations, dependent: :destroy
   validates :username, presence: true, uniqueness: true
 end


### PR DESCRIPTION
Added `dependent: :destroy` to consoles and user to allow deleting of fields when foreign key is in use